### PR TITLE
Fix off-by-one error in iTXt chunk parsing

### DIFF
--- a/src/io/nayuki/png/chunk/Itxt.java
+++ b/src/io/nayuki/png/chunk/Itxt.java
@@ -77,8 +77,8 @@ public record Itxt(
 			if (compMethod != 0)
 				throw new IllegalArgumentException("Invalid compression method");
 		} else if (compFlag == 1) {
-			if (compMethod > CompressionMethod.values().length)
-				throw new IllegalArgumentException("Unrecognized value for enumeration");
+			if (compMethod >= CompressionMethod.values().length)
+				throw new IllegalArgumentException("Unknown compression method");
 		} else
 			throw new IllegalArgumentException("Compression flag out of range");
 		String language = in.readString(StandardCharsets.ISO_8859_1, true);


### PR DESCRIPTION
Found by testing with brokensuite.

Here's the file that broke it
![itxt_compression_method](https://github.com/user-attachments/assets/4a00f0d7-8743-45fb-8515-d09dd64497ba)
