### PR TITLE
Allow a value of 0 in pHYs chunks

### DIFF
--- a/src/io/nayuki/png/chunk/Phys.java
+++ b/src/io/nayuki/png/chunk/Phys.java
@@ -30,7 +30,7 @@ public record Phys(
 	/*---- Constructor and factory ----*/
 	
 	public Phys {
-		if (pixelsPerUnitX <= 0 || pixelsPerUnitY <= 0)
+		if (pixelsPerUnitX < 0 || pixelsPerUnitY < 0)
 			throw new IllegalArgumentException("Non-positive physical density");
 		Objects.requireNonNull(unitSpecifier);
 	}


### PR DESCRIPTION
As far as I can tell that is allowed in the [spec](https://www.w3.org/TR/png-3/#11pHYs)