### PR TITLE
Disallow more duplicate chunks

### DIFF
--- a/src/io/nayuki/png/PngImage.java
+++ b/src/io/nayuki/png/PngImage.java
@@ -241,10 +241,14 @@ public final class PngImage {
 		"iCCP",
 		"IEND",
 		"IHDR",
+		"oFFs",
+		"pCAL",
 		"pHYs",
 		"PLTE",
 		"sBIT",
+		"sCAL",
 		"sRGB",
+		"sTER",
 		"tIME",
 		"tRNS"));
 	


### PR DESCRIPTION
Marks the PNG extension chunks as unique, as the [spec](https://w3c.github.io/png/extensions/Overview.html#Summary) says.

There's still more ordering issues that are not caught (mainly chunks being before/after IDATs), but this is at least an improvement.
Makes progress on getting the entirety of [ImageTestSuite](https://code.google.com/archive/p/imagetestsuite/) to fail.