### PR TITLE
Check chunk ordering around IDATs

### DIFF
--- a/src/io/nayuki/png/PngImage.java
+++ b/src/io/nayuki/png/PngImage.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;

--- a/src/io/nayuki/png/PngImage.java
+++ b/src/io/nayuki/png/PngImage.java
@@ -241,10 +241,14 @@ public final class PngImage {
 		"iCCP",
 		"IEND",
 		"IHDR",
+		"oFFs",
+		"pCAL",
 		"pHYs",
 		"PLTE",
 		"sBIT",
+		"sCAL",
 		"sRGB",
+		"sTER",
 		"tIME",
 		"tRNS"));
 	

--- a/src/io/nayuki/png/PngImage.java
+++ b/src/io/nayuki/png/PngImage.java
@@ -178,6 +178,8 @@ public final class PngImage {
 						yield State.DURING_IDATS;
 					} else if (chunk instanceof Iend)
 						throw new IllegalArgumentException("Unexpected IEND chunk");
+					else if (AFTER_IDAT_CHUNK_TYPES.contains(chunk.getType()))
+						throw new IllegalArgumentException("Unexpected " + chunk.getType() + " chunk before IDAT");
 					else {
 						afterIhdr.add(chunk);
 						yield State.AFTER_IHDR;
@@ -192,6 +194,8 @@ public final class PngImage {
 						yield State.DURING_IDATS;
 					} else if (chunk instanceof Iend)
 						yield State.AFTER_IEND;
+					else if (BEFORE_IDAT_CHUNK_TYPES.contains(chunk.getType()))
+						throw new IllegalArgumentException("Unexpected " + chunk.getType() + " chunk after IDAT");
 					else {
 						afterIdats.add(chunk);
 						yield State.AFTER_IDATS;
@@ -205,6 +209,8 @@ public final class PngImage {
 						yield State.AFTER_IEND;
 					else if (chunk instanceof Idat)
 						throw new IllegalArgumentException("Non-consecutive IDAT chunk");
+					else if (BEFORE_IDAT_CHUNK_TYPES.contains(chunk.getType()))
+						throw new IllegalArgumentException("Unexpected " + chunk.getType() + " chunk after IDAT");
 					else {
 						afterIdats.add(chunk);
 						yield State.AFTER_IDATS;
@@ -232,7 +238,7 @@ public final class PngImage {
 	}
 	
 	
-	private static final Set<String> UNIQUE_CHUNK_TYPES = new HashSet<>(Arrays.asList(
+	private static final Set<String> UNIQUE_CHUNK_TYPES = Set.of(
 		"acTL",
 		"bKGD",
 		"cHRM",
@@ -250,21 +256,44 @@ public final class PngImage {
 		"sRGB",
 		"sTER",
 		"tIME",
-		"tRNS"));
+		"tRNS");
 	
 	
-	private static final Set<String> BEFORE_PLTE_CHUNK_TYPES = new HashSet<>(Arrays.asList(
+	private static final Set<String> BEFORE_IDAT_CHUNK_TYPES = Set.of(
+		"acTL",
+		"bKGD",
+		"cHRM",
+		"eXIF",
+		"gAMA",
+		"hIST",
+		"iCCP",
+		"oFFs",
+		"pCAL",
+		"pHYs",
+		"sBIT",
+		"sCAL",
+		"sPTL",
+		"sRGB",
+		"sTER",
+		"tRNS");
+	
+	
+	private static final Set<String> AFTER_IDAT_CHUNK_TYPES = Set.of(
+		"fdAT");
+	
+	
+	private static final Set<String> BEFORE_PLTE_CHUNK_TYPES = Set.of(
 		"cHRM",
 		"gAMA",
 		"iCCP",
 		"sBIT",
-		"sRGB"));
+		"sRGB");
 	
 	
-	private static final Set<String> AFTER_PLTE_CHUNK_TYPES = new HashSet<>(Arrays.asList(
+	private static final Set<String> AFTER_PLTE_CHUNK_TYPES = Set.of(
 		"bKGD",
 		"hIST",
-		"tRNS"));
+		"tRNS");
 	
 	
 	/**


### PR DESCRIPTION
Check for chunk ordering around IDAT chunks, as some chunks have to appear before it (and one has to appear after).
See the [specification](https://www.w3.org/TR/png-3/#5ChunkOrdering) (and the [extension](https://w3c.github.io/png/extensions/Overview.html#Summary)).

Also replaces `new HashSet<>(Arrays.asList())` with `Set.of()`, which is nicer looking (and should be slightly faster).

Depends on #6 (mostly because I'm lazy :p)

Fixes most failures on [ImageTestSuite](https://code.google.com/archive/p/imagetestsuite/).